### PR TITLE
:sparkles: Alter export notebook, pass a config as a parameter

### DIFF
--- a/src/__myproject__/_export/p360_export.py
+++ b/src/__myproject__/_export/p360_export.py
@@ -3,17 +3,19 @@
 
 # COMMAND ----------
 
+import json
 import daipe as dp
 from p360_export.P360ExportRunner import P360ExportRunner
+from typing import Dict, Any
 
 # COMMAND ----------
 
 @dp.notebook_function()
 def init_widgets(widgets: dp.Widgets):
-    widgets.add_text("config_url", "", "Config url")
+    widgets.add_text("config", "", "Config")
 
 # COMMAND ----------
 
-@dp.notebook_function(dp.get_widget_value("config_url"))
-def export(config_url: str, p360_export_runner: P360ExportRunner):
-    p360_export_runner.export(config_url=config_url)
+@dp.notebook_function(dp.get_widget_value("config"))
+def export(config: Dict[str, Any], p360_export_runner: P360ExportRunner):
+    p360_export_runner.export(json.loads(config))


### PR DESCRIPTION
- Export job is called with config as param, export bundle was changed
  because of that -> export ntb needs to be as well.

## Motivation

Saving export information to json → sending url of that json to dbx, where we fetch data from that json, makes the whole process unnecessarily tangled. Thus we decided to send config straight to job as a parameter.